### PR TITLE
Fixed failure to upload when video takes long to load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
 	"selenium",
-	"webdriver_manager == 3.8.6",
+	"webdriver_manager",
   "toml"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
 	"selenium",
-	"webdriver_manager",
+	"webdriver_manager == 3.8.6",
   "toml"
 ]
 

--- a/src/tiktok_uploader/auth.py
+++ b/src/tiktok_uploader/auth.py
@@ -11,16 +11,25 @@ from tiktok_uploader import config, logger
 from tiktok_uploader.browsers import get_browser
 from tiktok_uploader.utils import green
 
+
 class AuthBackend:
     """
     Handles authentication for TikTokUploader
     """
+
     username: str
     password: str
     cookies: list
 
-    def __init__(self, username: str = '', password: str = '',
-                 cookies_list: list = None, cookies=None, sessionid: str = None):
+    def __init__(
+        self,
+        username: str = "",
+        password: str = "",
+        cookies_list: list = None,
+        cookies=None,
+        cookies_str=None,
+        sessionid: str = None,
+    ):
         """
         Creates the authenticaiton backend
 
@@ -34,8 +43,9 @@ class AuthBackend:
             raise InsufficientAuth()
 
         self.cookies = self.get_cookies(path=cookies) if cookies else []
+        self.cookies += self.get_cookies(cookies_str=cookies_str) if cookies_str else []
         self.cookies += cookies_list if cookies_list else []
-        self.cookies += [{'name': 'sessionid', 'value': sessionid}] if sessionid else []
+        self.cookies += [{"name": "sessionid", "value": sessionid}] if sessionid else []
 
         if not (self.cookies or (username and password)):
             raise InsufficientAuth()
@@ -52,7 +62,6 @@ class AuthBackend:
         elif cookies_list:
             logger.debug(green("Authenticating browser with cookies_list"))
 
-
     def authenticate_agent(self, driver):
         """
         Authenticates the agent using the browser backend
@@ -63,29 +72,36 @@ class AuthBackend:
 
         logger.debug(green("Authenticating browser with cookies"))
 
-        driver.get(config['paths']['main'])
+        driver.get(config["paths"]["main"])
 
-        WebDriverWait(driver, config['explicit_wait']).until(EC.title_contains("TikTok"))
+        WebDriverWait(driver, config["explicit_wait"]).until(
+            EC.title_contains("TikTok")
+        )
 
         for cookie in self.cookies:
             try:
                 driver.add_cookie(cookie)
             except Exception as _:
-                logger.error('Failed to add cookie %s', cookie)
+                logger.error("Failed to add cookie %s", cookie)
 
         return driver
 
-
-    def get_cookies(self, path: str) -> dict:
+    def get_cookies(
+        self, path: str | None = None, cookies_str: str | None = None
+    ) -> dict:
         """
         Gets cookies from the passed file using the netscape standard
         """
-        with open(path, 'r', encoding='utf-8') as file:
-            lines = file.read().split('\n')
+        if path:
+            with open(path, "r", encoding="utf-8") as file:
+                lines = file.read().split("\n")
+
+        else:
+            lines = cookies_str.split("\n")
 
         return_cookies = []
         for line in lines:
-            split = line.split('\t')
+            split = line.split("\t")
             if len(split) < 6:
                 continue
 
@@ -96,15 +112,17 @@ class AuthBackend:
             except ValueError:
                 split[4] = None
 
-            return_cookies.append({
-                'name': split[5],
-                'value': split[6],
-                'domain': split[0],
-                'path': split[2],
-            })
+            return_cookies.append(
+                {
+                    "name": split[5],
+                    "value": split[6],
+                    "domain": split[0],
+                    "path": split[2],
+                }
+            )
 
             if split[4]:
-                return_cookies[-1]['expiry'] = split[4]
+                return_cookies[-1]["expiry"] = split[4]
         return return_cookies
 
 
@@ -134,43 +152,49 @@ def login(driver, username: str, password: str):
     assert username and password, "Username and password are required"
 
     # checks if the browser is on TikTok
-    if not config['paths']['main'] in driver.current_url:
-        driver.get(config['paths']['main'])
+    if not config["paths"]["main"] in driver.current_url:
+        driver.get(config["paths"]["main"])
 
     # checks if the user is already logged in
-    if driver.get_cookie(config['selectors']['login']['cookie_of_interest']):
+    if driver.get_cookie(config["selectors"]["login"]["cookie_of_interest"]):
         # clears the existing cookies
         driver.delete_all_cookies()
 
     # goes to the login site
-    driver.get(config['paths']['login'])
+    driver.get(config["paths"]["login"])
 
     # selects and fills the login and the password
-    username_field = WebDriverWait(driver, config['explicit_wait']).until(
-        EC.presence_of_element_located((By.XPATH, config['selectors']['login']['username_field']))
+    username_field = WebDriverWait(driver, config["explicit_wait"]).until(
+        EC.presence_of_element_located(
+            (By.XPATH, config["selectors"]["login"]["username_field"])
         )
+    )
     username_field.clear()
     username_field.send_keys(username)
 
-    password_field = driver.find_element(By.XPATH, config['selectors']['login']['password_field'])
+    password_field = driver.find_element(
+        By.XPATH, config["selectors"]["login"]["password_field"]
+    )
     password_field.clear()
     password_field.send_keys(password)
 
     # submits the form
-    submit = driver.find_element(By.XPATH, config['selectors']['login']['login_button'])
+    submit = driver.find_element(By.XPATH, config["selectors"]["login"]["login_button"])
     submit.click()
 
-    print(f'Complete the captcha for {username}')
+    print(f"Complete the captcha for {username}")
 
     # Wait until the session id cookie is set
     start_time = time()
-    while not driver.get_cookie(config['selectors']['login']['cookie_of_interest']):
+    while not driver.get_cookie(config["selectors"]["login"]["cookie_of_interest"]):
         sleep(0.5)
-        if time() - start_time > config['explicit_wait']:
-            raise InsufficientAuth() # TODO: Make this something more real
+        if time() - start_time > config["explicit_wait"]:
+            raise InsufficientAuth()  # TODO: Make this something more real
 
     # wait until the url changes
-    WebDriverWait(driver, config['explicit_wait']).until(EC.url_changes(config['paths']['login']))
+    WebDriverWait(driver, config["explicit_wait"]).until(
+        EC.url_changes(config["paths"]["login"])
+    )
 
     return driver.get_cookies()
 
@@ -183,10 +207,10 @@ def get_username_and_password(login_info: tuple or dict):
         return login_info[0], login_info[1]
 
     # checks if they used email or username
-    if 'email' in login_info:
-        return login_info['email'], login_info['password']
-    elif 'username' in login_info:
-        return login_info['username'], login_info['password']
+    if "email" in login_info:
+        return login_info["email"], login_info["password"]
+    elif "username" in login_info:
+        return login_info["username"], login_info["password"]
 
     raise InsufficientAuth()
 

--- a/src/tiktok_uploader/browsers.py
+++ b/src/tiktok_uploader/browsers.py
@@ -22,7 +22,7 @@ from selenium import webdriver
 from tiktok_uploader import config, logger
 
 
-def get_browser(name: str = 'chrome', options=None, *args, **kwargs) -> webdriver:
+def get_browser(name: str = "chrome", options=None, *args, **kwargs) -> webdriver:
     """
     Gets a browser based on the name with the ability to pass in additional arguments
     """
@@ -41,12 +41,12 @@ def get_browser(name: str = 'chrome', options=None, *args, **kwargs) -> webdrive
     else:
         driver = driver_to_use(options=options)
 
-    driver.implicitly_wait(config['implicit_wait'])
+    driver.implicitly_wait(config["implicit_wait"])
 
     return driver
 
 
-def get_driver(name: str = 'chrome', *args, **kwargs) -> webdriver:
+def get_driver(name: str = "chrome", *args, **kwargs) -> webdriver:
     """
     Gets the web driver function for the browser
     """
@@ -56,7 +56,7 @@ def get_driver(name: str = 'chrome', *args, **kwargs) -> webdriver:
     raise UnsupportedBrowserException()
 
 
-def get_service(name: str = 'chrome'):
+def get_service(name: str = "chrome"):
     """
     Gets a service to install the browser driver per webdriver-manager docs
 
@@ -65,7 +65,7 @@ def get_service(name: str = 'chrome'):
     if _clean_name(name) in services:
         return services[name]()
 
-    return None # Safari doesn't need a service
+    return None  # Safari doesn't need a service
 
 
 def get_default_options(name: str, *args, **kwargs):
@@ -88,16 +88,16 @@ def chrome_defaults(*args, headless: bool = False, **kwargs) -> ChromeOptions:
     options = ChromeOptions()
 
     ## regular
-    options.add_argument('--disable-blink-features=AutomationControlled')
-    options.add_argument('--profile-directory=Default')
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_argument("--profile-directory=Default")
 
     ## experimental
-    options.add_experimental_option('excludeSwitches', ['enable-automation'])
-    options.add_experimental_option('useAutomationExtension', False)
+    options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option("useAutomationExtension", False)
 
     # headless
     if headless:
-        options.add_argument('--headless=new')
+        options.add_argument("--headless=new")
 
     return options
 
@@ -112,7 +112,7 @@ def firefox_defaults(*args, headless: bool = False, **kwargs) -> FirefoxOptions:
     # default options
 
     if headless:
-        options.add_argument('--headless')
+        options.add_argument("--headless")
 
     return options
 
@@ -126,7 +126,7 @@ def safari_defaults(*args, headless: bool = False, **kwargs) -> SafariOptions:
     # default options
 
     if headless:
-        options.add_argument('--headless')
+        options.add_argument("--headless")
 
     return options
 
@@ -140,9 +140,10 @@ def edge_defaults(*args, headless: bool = False, **kwargs) -> EdgeOptions:
     # default options
 
     if headless:
-        options.add_argument('--headless')
+        options.add_argument("--headless")
 
     return options
+
 
 # Misc
 class UnsupportedBrowserException(Exception):
@@ -168,22 +169,22 @@ def _clean_name(name: str) -> str:
 
 
 drivers = {
-    'chrome': webdriver.Chrome,
-    'firefox': webdriver.Firefox,
-    'safari': webdriver.Safari,
-    'edge': webdriver.ChromiumEdge,
+    "chrome": webdriver.Chrome,
+    "firefox": webdriver.Firefox,
+    "safari": webdriver.Safari,
+    "edge": webdriver.ChromiumEdge,
 }
 
 defaults = {
-    'chrome': chrome_defaults,
-    'firefox': firefox_defaults,
-    'safari': safari_defaults,
-    'edge': edge_defaults,
+    "chrome": chrome_defaults,
+    "firefox": firefox_defaults,
+    "safari": safari_defaults,
+    "edge": edge_defaults,
 }
 
 
 services = {
-    'chrome': lambda : ChromeService(ChromeDriverManager().install()),
-    'firefox': lambda : FirefoxService(GeckoDriverManager().install()),
-    'edge': lambda : EdgeService(EdgeChromiumDriverManager().install()),
+    "chrome": lambda: ChromeService(),
+    "firefox": lambda: FirefoxService(),
+    "edge": lambda: EdgeService(),
 }

--- a/src/tiktok_uploader/browsers.py
+++ b/src/tiktok_uploader/browsers.py
@@ -80,7 +80,9 @@ def get_default_options(name: str, *args, **kwargs):
     raise UnsupportedBrowserException()
 
 
-def chrome_defaults(*args, headless: bool = False, **kwargs) -> ChromeOptions:
+def chrome_defaults(
+    *args, headless: bool = False, is_gcp: bool = False, **kwargs
+) -> ChromeOptions:
     """
     Creates Chrome with Options
     """
@@ -98,6 +100,12 @@ def chrome_defaults(*args, headless: bool = False, **kwargs) -> ChromeOptions:
     # headless
     if headless:
         options.add_argument("--headless=new")
+        
+    if is_gcp:
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--disable-gpu")
+        options.add_argument("window-size=1024,768")
 
     return options
 

--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -36,13 +36,14 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	
 	[selectors.upload]
 	iframe = "//iframe"
+	creator_center_iframe = "//iframe[@src='https://www.tiktok.com/creator#/upload?scene=creator_center']"
 	
 	upload_video = "//input[@type='file']"
 	upload_in_progress = "//*[.='Cancel']"
 	upload_confirmation = "//video" 
 	process_confirmation = "//img[@draggable='false']"
 
-	description = "//div[@contenteditable='true']"
+	description = "//*[.='Caption']/../../..//div[@contenteditable='true']"
 
 	visibility = "//div[@class='tiktok-select-selector']"
 	options = ["Public", "Friends", "Private"]

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -166,7 +166,18 @@ def _go_to_upload(driver) -> None:
         (By.XPATH, config['selectors']['upload']['iframe'])
         )
     iframe = WebDriverWait(driver, config['explicit_wait']).until(iframe_selector)
-    driver.switch_to.frame(iframe)
+    
+    creator_center_iframe_selector = EC.presence_of_element_located(
+        (By.XPATH, config['selectors']['upload']['creator_center_iframe'])
+    )
+    
+    try:
+        creator_center_iframe = WebDriverWait(driver, config['explicit_wait']).until(creator_center_iframe_selector)
+        driver.switch_to.frame(creator_center_iframe)
+    except Exception as _:
+        driver.switch_to.frame(iframe)
+    
+    
 
     # waits for the iframe to load
     root_selector = EC.presence_of_element_located((By.ID, 'root'))

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -76,6 +76,7 @@ def upload_videos(
     browser_agent=None,
     on_complete=None,
     headless=False,
+    is_gcp=False,
     num_retires: int = 1,
     *args,
     **kwargs
@@ -120,7 +121,9 @@ def upload_videos(
             browser,
             "in headless mode" if headless else "",
         )
-        driver = get_browser(name=browser, headless=headless, *args, **kwargs)
+        driver = get_browser(
+            name=browser, headless=headless, is_gcp=is_gcp, *args, **kwargs
+        )
     else:
         logger.debug("Using user-defined browser agent")
         driver = browser_agent

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -288,9 +288,8 @@ def _set_video(driver, path: str = '', num_retries: int = 3, **kwargs) -> None:
                 (By.XPATH, config['selectors']['upload']['upload_confirmation'])
                 )
 
-            # NOTE (IMPORTANT): implicit wait as video should already be uploaded if not failed
             # An exception throw here means the video failed to upload an a retry is needed
-            WebDriverWait(driver, config['implicit_wait']).until(upload_confirmation)
+            WebDriverWait(driver, config['explicit_wait']).until(upload_confirmation)
 
             # wait until a non-draggable image is found
             process_confirmation = EC.presence_of_element_located(


### PR DESCRIPTION
When the user's internet connection is specially slow, a loading screen is displayed after the video is finished processing.
This causes the script to fail, since the wait time of 3 seconds is not sufficient.
Changing the wait from implicit to explicit minimizes (although doesn't completely eliminate) this problem.