### PR TITLE
add pytz to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ classifiers = [
 dependencies = [
 	"selenium",
 	"webdriver_manager",
-  "toml"
+  "toml",
+  "pytz"
 ]
 
 [build-system]


### PR DESCRIPTION
hi, when i follow the following instruction install tiktok-uploader

<img width="854" alt="image" src="https://github.com/wkaisertexas/tiktok-uploader/assets/5053620/9c9daa22-0bc4-4206-a7c4-6e5e729304fb">

and run got an ModuleNotFoundError
<img width="1774" alt="image" src="https://github.com/wkaisertexas/tiktok-uploader/assets/5053620/51f2bb47-52fc-475c-af50-761aaa488ba9">

OS: Mac os 13.4 (22F66)
Python: CPython 3.11.5

So i added it and test it in my virtualenv, now works.
<img width="1659" alt="image" src="https://github.com/wkaisertexas/tiktok-uploader/assets/5053620/77aa04b1-dc93-4c80-8fb5-1bbf70d99729">

<img width="1266" alt="image" src="https://github.com/wkaisertexas/tiktok-uploader/assets/5053620/32fe4fa8-4108-4544-b5f6-29b85b4552dc">

