### PR TITLE
Issue 53

### DIFF
--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -178,7 +178,7 @@ def complete_upload_form(driver, path: str, description: str, schedule: datetime
         The path to the video to upload
     """
     _go_to_upload(driver)
-    _remove_cookies_window(driver)
+    #  _remove_cookies_window(driver)
     _set_video(driver, path=path, **kwargs)
     _remove_split_window(driver)
     _set_interactivity(driver, **kwargs)

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -212,6 +212,9 @@ def _go_to_upload(driver) -> None:
     root_selector = EC.presence_of_element_located((By.ID, 'root'))
     WebDriverWait(driver, config['explicit_wait']).until(root_selector)
 
+    # Return to default webpage
+    driver.switch_to.default_content()
+
 def _change_to_upload_iframe(driver) -> None:
     """
     Switch to the iframe of the upload page
@@ -370,10 +373,7 @@ def _remove_cookies_window(driver) -> None:
     ----------
     driver : selenium.webdriver
     """
-    
-    # Return to default webpage
-    driver.switch_to.default_content()
-        
+
     logger.debug(green(f'Removing cookies window'))
     cookies_banner = WebDriverWait(driver, config['implicit_wait']).until(
         EC.presence_of_element_located((By.TAG_NAME, config['selectors']['upload']['cookies_banner']['banner'])))


### PR DESCRIPTION
### The function `remove_cookies_window()` isn't working.

During my investigation, I discovered the following issues:
- The banner exists, but with a size of 0x0 and without content in the shadow root.
- When attempting to click the button, it fails because the button doesn't exist.
- The function `remove_cookies_window()` does not account for the scenario where the cookie window does not exist.

I have:
- commented out `remove_cookies_window()` (it should be fixed)
- decrease the coupling

I tested it, and it works. However, my tests were only in one account, and the cookies window did not appear. Therefore, it needs to be tested when the cookies window shows up.

[Issue 53
](https://github.com/wkaisertexas/tiktok-uploader/issues/53)