### PR TITLE
failure right after video upload verification

### DIFF
--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -40,7 +40,7 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	split_window = "//button[./div[text()='Not now']]"
 	upload_video = "//input[@type='file']"
 	upload_finished = "//div[contains(@class, 'btn-cancel')]"
-	upload_confirmation = "//video" 
+	upload_confirmation = "//div[contains(@class, 'mobile-preview-player')]"
 	process_confirmation = "//img[@draggable='false']"
 
 	description = "//div[@contenteditable='true']"

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -352,12 +352,6 @@ def _set_video(driver, path: str = '', num_retries: int = 3, **kwargs) -> None:
 
             # An exception throw here means the video failed to upload an a retry is needed
             WebDriverWait(driver, config['explicit_wait']).until(upload_confirmation)
-
-            # wait until a non-draggable image is found
-            process_confirmation = EC.presence_of_element_located(
-                (By.XPATH, config['selectors']['upload']['process_confirmation'])
-                )
-            WebDriverWait(driver, config['explicit_wait']).until(process_confirmation)
             return
         except Exception as exception:
             print(exception)


### PR DESCRIPTION
Hello I created this pull request to fix uplaod process. I my case the script would stuck right after the upload trying to search for a non  dragable image. Additionaly I changed the path upload_confirmation as I was not able to find any video tag after the video upload