### PR TITLE
Selector Update and Threading Enablement

### DIFF
--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -58,7 +58,7 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	stitch = "//label[.='Stitch']/following-sibling::div/input"
 
 	post = "//div[contains(@class, 'btn-post')]"
-	post_confirmation = "//div[contains(@class, 'tiktok-modal__modal-wrapper')]//div[contains(@class, 'tiktok-modal__modal-title') and contains(text(), 'Your videos are being uploaded to TikTok!')]"
+	post_confirmation = "//div[contains(@class, 'tiktok-modal__modal-wrapper')]//div[contains(@class, 'tiktok-modal__modal-title') and contains(text(), 'Your videos are being posted to TikTok!')]"
 
 	[selectors.schedule]
 	switch = "//*[@id='tux-3']"


### PR DESCRIPTION
This PR updates the selector for post completion to maintain the functionality at the end of the `upload.py` script. Previously since TikTok has changed the text on the post completion modal, the program would quit unexpectedly.

I have also implemented threading into the `complete_upload_form` which forces the function to wait until the video is uploaded before inserting the description and making the required selections.

Additionally. I have removed some of the `webdriverWait` functionality which was causing the script to halt and eventually time out. With these changes, I have confirmed that the script will still wait for the video/videos to be uploaded before clicking the post button.

- [x] Tests have been ran
- [x] Manual testing has been completed
- [x] Script is working 🙌

![image](https://github.com/wkaisertexas/tiktok-uploader/assets/63158857/3e3a408a-e82f-4eb3-a686-608feb6f9935)
