### PR TITLE
Simplifies the _set_description function fixing hashtags and mentions

### DIFF
--- a/examples/basic_upload.py
+++ b/examples/basic_upload.py
@@ -13,5 +13,5 @@ if __name__ == "__main__":
 
     # upload video to TikTok
     upload_video(FILENAME,
-                 description="This is a video I just downloaded",
+                 description="This is a #cool video I just downloaded #wow check it out on @tiktok",
                  cookies="cookies.txt")

--- a/examples/basic_upload.py
+++ b/examples/basic_upload.py
@@ -13,5 +13,5 @@ if __name__ == "__main__":
 
     # upload video to TikTok
     upload_video(FILENAME,
-                 description="This is a #cool video I just downloaded #wow check it out on @tiktok",
+                 description="This is a #cool video I just downloaded. #wow check it out on @tiktok",
                  cookies="cookies.txt")

--- a/examples/basic_upload.py
+++ b/examples/basic_upload.py
@@ -13,5 +13,5 @@ if __name__ == "__main__":
 
     # upload video to TikTok
     upload_video(FILENAME,
-                 description="This is a #cool video I just downloaded. #wow check it out on @tiktok",
+                 description="This is a #cool video I just downloaded. #wow #cool check it out on @tiktok",
                  cookies="cookies.txt")

--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -48,7 +48,7 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	visibility = "//div[@class='tiktok-select-selector']"
 	options = ["Public", "Friends", "Private"]
 
-	mention_box = "//input[contains(concat(' ', normalize-space(@class), ' '), 'search-friends')]"
+	mention_box = "//div[contains(@class, 'mention-list-popover')]"
 
 	comment = "//label[.='Comment']/following-sibling::div/input"
 	duet = "//label[.='Duet']/following-sibling::div/input"

--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -49,6 +49,7 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	options = ["Public", "Friends", "Private"]
 
 	mention_box = "//div[contains(@class, 'mention-list-popover')]"
+	mention_box_user_id = "//span[contains(@class, 'user-id')]"
 
 	comment = "//label[.='Comment']/following-sibling::div/input"
 	duet = "//label[.='Duet']/following-sibling::div/input"

--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -48,9 +48,6 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	visibility = "//div[@class='tiktok-select-selector']"
 	options = ["Public", "Friends", "Private"]
 
-	hashtags = "//div[@class='mentionSuggestions']//*[contains(text(), '{}')]"
-	mentions = "//div[contains(concat(' ', normalize-space(@class), ' '), 'user-id') and .='{}']/.."
-
 	mention_box = "//input[contains(concat(' ', normalize-space(@class), ' '), 'search-friends')]"
 
 	comment = "//label[.='Comment']/following-sibling::div/input"

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -280,8 +280,6 @@ def _set_description(driver, description: str) -> None:
     _clear(desc)
 
     WebDriverWait(driver, config['explicit_wait']).until(lambda driver: desc.text == '')
-
-    time.sleep(config['implicit_wait'])
     
     desc.click()
 

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -298,7 +298,11 @@ def _set_description(driver, description: str) -> None:
                 desc.send_keys(Keys.ENTER)
             elif word[0] == "@":
                 desc.send_keys(word)
-                desc.send_keys(' ' + Keys.BACKSPACE)
+                time.sleep(1)
+                desc.send_keys(' ')
+                time.sleep(1)
+                desc.send_keys(Keys.BACKSPACE)
+                time.sleep(1)
                 EC.presence_of_element_located(
                     (By.XPATH, config['selectors']['upload']['mention_box'])
                 )

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -6,6 +6,7 @@ Key Functions
 upload_video : Uploads a single TikTok video
 upload_videos : Uploads multiple TikTok videos
 """
+
 from os.path import abspath, exists
 from typing import List
 import time
@@ -275,6 +276,7 @@ def _set_description(driver, description: str) -> None:
     # desc populates with filename before clearing
     WebDriverWait(driver, config['explicit_wait']).until(lambda driver: desc.text != '')
 
+    desc.send_keys(Keys.END)
     _clear(desc)
 
     WebDriverWait(driver, config['explicit_wait']).until(lambda driver: desc.text == '')
@@ -289,12 +291,18 @@ def _set_description(driver, description: str) -> None:
             if word[0] == "#":
                 desc.send_keys(word)
                 desc.send_keys(' ' + Keys.BACKSPACE)
-                time.sleep(config['implicit_wait'])
+                EC.presence_of_element_located(
+                    (By.XPATH, config['selectors']['upload']['mention_box'])
+                )
+                time.sleep(2)
                 desc.send_keys(Keys.ENTER)
             elif word[0] == "@":
                 desc.send_keys(word)
                 desc.send_keys(' ' + Keys.BACKSPACE)
-                time.sleep(2*config['implicit_wait'])
+                EC.presence_of_element_located(
+                    (By.XPATH, config['selectors']['upload']['mention_box'])
+                )
+                time.sleep(2)
                 desc.send_keys(Keys.ENTER)
             else:
                 desc.send_keys(word + " ")
@@ -314,7 +322,6 @@ def _clear(element) -> None:
         The text box to clear
     """
     element.send_keys(2 * len(element.text) * Keys.BACKSPACE)
-
 
 def _set_video(driver, path: str = '', num_retries: int = 3, **kwargs) -> None:
     """

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -289,22 +289,18 @@ def _set_description(driver, description: str) -> None:
             if word[0] == "#":
                 desc.send_keys(word)
                 desc.send_keys(' ' + Keys.BACKSPACE)
-                EC.presence_of_element_located(
+                WebDriverWait(driver, config['implicit_wait']).until(EC.presence_of_element_located(
                     (By.XPATH, config['selectors']['upload']['mention_box'])
-                )
-                time.sleep(2)
+                ))
                 desc.send_keys(Keys.ENTER)
             elif word[0] == "@":
                 desc.send_keys(word)
-                time.sleep(1)
                 desc.send_keys(' ')
-                time.sleep(1)
                 desc.send_keys(Keys.BACKSPACE)
-                time.sleep(1)
-                EC.presence_of_element_located(
+                WebDriverWait(driver, config['implicit_wait']).until(EC.presence_of_element_located(
                     (By.XPATH, config['selectors']['upload']['mention_box'])
-                )
-                time.sleep(2)
+                ))
+                time.sleep(1)
                 desc.send_keys(Keys.ENTER)
             else:
                 desc.send_keys(word + " ")
@@ -342,6 +338,12 @@ def _set_video(driver, path: str = '', num_retries: int = 3, **kwargs) -> None:
     for _ in range(num_retries):
         try:
             _change_to_upload_iframe(driver)
+            # Wait For Input File
+            driverWait = WebDriverWait(driver, config['explicit_wait'])
+            upload_boxWait = EC.presence_of_element_located(
+                (By.XPATH, config['selectors']['upload']['upload_video'])
+                )
+            driverWait.until(upload_boxWait)
             upload_box = driver.find_element(
                 By.XPATH, config['selectors']['upload']['upload_video']
             )


### PR DESCRIPTION
This PR solves a problem that has been mentioned in a couple of issues where the hashtags and mentions are not being added correctly. The most likely reason for this is simply changes to the TikTok UI however they have made the `hashtag` and `mention` selection stage much more difficult to execute because there are no good elements to anchor to.

One effect that I noticed whilst testing the code is that if a space is typed after a hashtag and then backspaced, the first hashtag suggestion will be an exact match of the hashtag you are trying to add, meaning we do not have to anchor to an element and click it, we can simply send an `ENTER` key. The same applies to the mention functionality. This meant that the size of the `_set_description` function can be greatly reduced. I also fine-tuned the timing between actions to make sure that the correct values will be inserted into the description, for this I used the implicit wait value that exists in the config.

Because we no longer have to select the dropdown elements, I have removed these selectors from the config file.

In order to show the functionality working again, I have added a hashtag and mention into the description string in the `basic_upload.py` file.

Hopefully this will close one or two issues on this project.

Below is a screenshot of the updated script in action, correctly adding hashtags and mentions:

![image](https://github.com/wkaisertexas/tiktok-uploader/assets/63158857/a211b0c6-14bf-491d-b94f-259087a8f9d2)

Co-authored-by: Callum Fortune <callumfortune03@outlook.com>
Co-authored-by: Jamadoo <jamadoo>
