### PR TITLE
added 1 sec wait between adding new hashtags, so they become clickable

### DIFF
--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -12,6 +12,9 @@ implicit_wait = 5  # seconds
 explicit_wait = 60 # seconds
 uploading_wait = 180 # seconds
 
+# Wait time between adding hashtags
+add_hashtag_wait = 1 # seconds
+
 supported_file_types = ["mp4", "mov", "avi", "wmv", "flv", "webm", "mkv", "m4v", "3gp", "3g2", "gif"]
 
 max_description_length = 150 # characters

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -372,6 +372,7 @@ def _set_description(driver, description: str) -> None:
                         (By.XPATH, config["selectors"]["upload"]["mention_box"])
                     )
                 )
+                time.sleep(config["add_hashtag_wait"])
                 desc.send_keys(Keys.ENTER)
             elif word[0] == "@":
                 logger.debug(green("- Adding Mention: " + word))


### PR DESCRIPTION
i found, that hashtags, which are added in the description are not clickable. When i added 1 sec. wait between adding each hashtag - hashtags became clickable. 
https://www.youtube.com/watch?v=MoUh1rIIMV0 - without wait
https://www.youtube.com/watch?v=1wsyBB4Gqd4 - with wait

PS. I tried 0.5 sec wait but still with this wait couple of hashtags were not clickable.