### PR TITLE
Fix: Error Clicking Post Button

### DIFF
--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -755,10 +755,9 @@ def _post_video(driver) -> None:
     logger.debug(green("Clicking the post button"))
 
     try:
-        post = WebDriverWait(driver, config["implicit_wait"]).until(
-            EC.element_to_be_clickable(
-                (By.XPATH, config["selectors"]["upload"]["post"])
-            )
+        post = WebDriverWait(driver, config["uploading_wait"]).until(
+            lambda d: (el := d.find_element(By.XPATH, config["selectors"]["upload"]["post"])) and
+                      el.get_attribute("data-disabled") == "false" and el
         )
         driver.execute_script(
             "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});", post


### PR DESCRIPTION
🛠️ **Reworked Post Button Wait Logic**

* Updated the logic to wait **before** clicking the Post button.
* Replaced the use of `element_to_be_clickable` with a manual check of the `data-disabled` attribute to determine when the Post button is active and ready to be clicked.

Resolves #202 