### PR TITLE
Fix: Add check for new post confirmation text

### DIFF
--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -59,7 +59,7 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	stitch = "//label[.='Stitch']/following-sibling::div/input"
 
 	post = "//button[@data-e2e='post_video_button']"
-	post_confirmation = "//div[contains(text(), 'Your video has been uploaded') or contains(text(), '视频已发布')]"
+	post_confirmation = "//div[contains(text(), 'Your video has been uploaded') or contains(text(), '视频已发布') or contains(text(), 'Video published')]"
 
 
 	[selectors.schedule]


### PR DESCRIPTION
The previous checks for a div with the specific text;"'Your video has been uploaded'". Updated to also check for the text "'Video published'".

In my case, only the latter would appear as a post confirmation. This ensures posts are correctly acknowledged as published and prevents upload from crashing.