### PR TITLE
Handling post_now button and removing cookies window

### DIFF
--- a/src/tiktok_uploader/config.py
+++ b/src/tiktok_uploader/config.py
@@ -81,6 +81,7 @@ class UploadSelectors(StrictModel):
     stitch: str
 
     post: str
+    post_now: str
     post_confirmation: str
 
     cookies_banner: CookiesBanner

--- a/src/tiktok_uploader/config.toml
+++ b/src/tiktok_uploader/config.toml
@@ -59,6 +59,7 @@ user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 	stitch = "//label[.='Stitch']/following-sibling::div/input"
 
 	post = "//button[@data-e2e='post_video_button']"
+	post_now = "//button[.//div[text()='Post now']]"
 	post_confirmation = "//div[contains(text(), 'Your video has been uploaded') or contains(text(), '视频已发布') or contains(text(), 'Video published')]"
 
 

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -278,7 +278,7 @@ def complete_upload_form(
         The path to the video to upload
     """
     _go_to_upload(driver)
-    #  _remove_cookies_window(driver)
+    _remove_cookies_window(driver)
 
     upload_complete_event = threading.Event()
 
@@ -522,27 +522,16 @@ def _remove_cookies_window(driver) -> None:
     """
 
     logger.debug(green("Removing cookies window"))
-    cookies_banner = WebDriverWait(driver, config.implicit_wait).until(
+    WebDriverWait(driver, config.implicit_wait).until(
         EC.presence_of_element_located(
             (By.TAG_NAME, config.selectors.upload.cookies_banner.banner)
         )
     )
 
-    item = WebDriverWait(driver, config.implicit_wait).until(
-        EC.visibility_of(
-            cookies_banner.shadow_root.find_element(
-                By.CSS_SELECTOR,
-                config.selectors.upload.cookies_banner.button,
-            )
-        )
+    driver.execute_script(
+        "document.querySelector(arguments[0]).remove()",
+        config["selectors"]["upload"]["cookies_banner"]["banner"],
     )
-
-    # Wait that the Decline all button is clickable
-    decline_button = WebDriverWait(driver, config.implicit_wait).until(
-        EC.element_to_be_clickable(item.find_elements(By.TAG_NAME, "button")[0])
-    )
-
-    decline_button.click()
 
 
 def _remove_split_window(driver: WebDriver) -> None:

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -779,6 +779,18 @@ def _post_video(driver: WebDriver) -> None:
         logger.debug(green("Trying to click on the button again"))
         driver.execute_script('document.querySelector(".TUXButton--primary").click()')
 
+    # wait for button with text "Post now" and click it if it exists
+    try:
+        print(green("Waiting for 'Post now' button"))
+        logger.debug(green("Waiting for 'Post now' button"))
+        post_now_button = WebDriverWait(driver, config["implicit_wait"]).until(
+            EC.element_to_be_clickable((By.XPATH, config["selectors"]["upload"]["post_now"]))
+        )
+        post_now_button.click()
+    except TimeoutException:
+        print("No 'Post now' button found, proceeding without it")
+        logger.debug("No 'Post now' button found, proceeding")
+
     # waits for the video to upload
     post_confirmation = EC.presence_of_element_located(
         (By.XPATH, config["selectors"]["upload"]["post_confirmation"])

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -530,7 +530,7 @@ def _remove_cookies_window(driver) -> None:
 
     driver.execute_script(
         "document.querySelector(arguments[0]).remove()",
-        config["selectors"]["upload"]["cookies_banner"]["banner"],
+        config.selectors.upload.cookies_banner.banner,
     )
 
 
@@ -837,9 +837,9 @@ def _post_video(driver: WebDriver) -> None:
     # wait for button with text "Post now" and click it if it exists
     try:
         logger.debug(green("Waiting for 'Post now' button"))
-        post_now_button = WebDriverWait(driver, config["implicit_wait"]).until(
+        post_now_button = WebDriverWait(driver, config.implicit_wait).until(
             EC.element_to_be_clickable(
-                (By.XPATH, config["selectors"]["upload"]["post_now"])
+                (By.XPATH, config.selectors.upload.post_now)
             )
         )
         post_now_button.click()

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -849,7 +849,9 @@ def _post_video(driver: WebDriver) -> None:
     try:
         logger.debug(green("Waiting for 'Post now' button"))
         post_now_button = WebDriverWait(driver, config["implicit_wait"]).until(
-            EC.element_to_be_clickable((By.XPATH, config["selectors"]["upload"]["post_now"]))
+            EC.element_to_be_clickable(
+                (By.XPATH, config["selectors"]["upload"]["post_now"])
+            )
         )
         post_now_button.click()
     except TimeoutException:

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -781,15 +781,13 @@ def _post_video(driver: WebDriver) -> None:
 
     # wait for button with text "Post now" and click it if it exists
     try:
-        print(green("Waiting for 'Post now' button"))
         logger.debug(green("Waiting for 'Post now' button"))
         post_now_button = WebDriverWait(driver, config["implicit_wait"]).until(
             EC.element_to_be_clickable((By.XPATH, config["selectors"]["upload"]["post_now"]))
         )
         post_now_button.click()
     except TimeoutException:
-        print("No 'Post now' button found, proceeding without it")
-        logger.debug("No 'Post now' button found, proceeding")
+        logger.debug("No 'Post now' button found, proceeding without it")
 
     # waits for the video to upload
     post_confirmation = EC.presence_of_element_located(

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -838,9 +838,7 @@ def _post_video(driver: WebDriver) -> None:
     try:
         logger.debug(green("Waiting for 'Post now' button"))
         post_now_button = WebDriverWait(driver, config.implicit_wait).until(
-            EC.element_to_be_clickable(
-                (By.XPATH, config.selectors.upload.post_now)
-            )
+            EC.element_to_be_clickable((By.XPATH, config.selectors.upload.post_now))
         )
         post_now_button.click()
     except TimeoutException:


### PR DESCRIPTION
- Handling the new button `post_now`, forked the code from #208 
- Removed cookies window instead of clicking on decline button that can cause crash because of shadow root

