### PR TITLE
sorting imports

### DIFF
--- a/examples/multiple_videos_at_once.py
+++ b/examples/multiple_videos_at_once.py
@@ -2,11 +2,11 @@
 Uploads multiple videos downloaded from the internet
 """
 
-from tiktok_uploader.upload import upload_videos
+import urllib.request
+
 from tiktok_uploader.auth import AuthBackend
 from tiktok_uploader.types import VideoDict
-
-import urllib.request
+from tiktok_uploader.upload import upload_videos
 
 URL = "https://raw.githubusercontent.com/wkaisertexas/wkaisertexas.github.io/main/upload.mp4"
 FILENAME = "upload.mp4"

--- a/examples/private_upload.py
+++ b/examples/private_upload.py
@@ -2,9 +2,9 @@
 Example of uploading a private video to TikTok
 """
 
-from tiktok_uploader.upload import upload_video, upload_videos
 from tiktok_uploader.auth import AuthBackend
 from tiktok_uploader.types import VideoDict
+from tiktok_uploader.upload import upload_video, upload_videos
 
 # Upload a private video (only visible to you)
 upload_video(

--- a/ruff.toml
+++ b/ruff.toml
@@ -34,12 +34,12 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.9
-target-version = "py39"
+# Assume Python 3.12
+target-version = "py312"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/src/tiktok_uploader/__init__.py
+++ b/src/tiktok_uploader/__init__.py
@@ -2,8 +2,8 @@
 TikTok Uploader Initialization
 """
 
-from os.path import abspath, join, dirname
 import logging
+from os.path import abspath, dirname, join
 
 from tiktok_uploader.config import load_config
 

--- a/src/tiktok_uploader/auth.py
+++ b/src/tiktok_uploader/auth.py
@@ -1,18 +1,17 @@
 """Handles authentication for TikTokUploader"""
 
 from http import cookiejar
-from time import time, sleep
+from time import sleep, time
 
 from selenium.webdriver.common.by import By
-
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 from tiktok_uploader import config, logger
 from tiktok_uploader.browsers import get_browser
-from tiktok_uploader.utils import green
 from tiktok_uploader.types import Cookie, cookie_from_dict
+from tiktok_uploader.utils import green
 
 
 class AuthBackend:

--- a/src/tiktok_uploader/browsers.py
+++ b/src/tiktok_uploader/browsers.py
@@ -1,31 +1,29 @@
 """Gets the browser's given the user's input"""
 
-from selenium.webdriver.remote.webdriver import WebDriver
+from collections.abc import Callable
+from typing import Any, Literal
 
+from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.webdriver.safari.options import Options as SafariOptions
-from selenium.webdriver.edge.options import Options as EdgeOptions
-from selenium.webdriver.common.options import BaseOptions
-from selenium.webdriver.common.service import Service
 
 # Webdriver managers
 from selenium.webdriver.chrome.service import Service as ChromeService
-from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.common.options import BaseOptions
+from selenium.webdriver.common.service import Service
+from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.edge.service import Service as EdgeService
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.firefox.service import Service as FirefoxService
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.safari.options import Options as SafariOptions
+from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.microsoft import EdgeChromiumDriverManager
-from selenium.webdriver.edge.service import Service as EdgeService
-
-from selenium import webdriver
 
 from tiktok_uploader import config
 from tiktok_uploader.proxy_auth_extension.proxy_auth_extension import (
     generate_proxy_auth_extension,
 )
-
-from typing import Literal, Any
-from collections.abc import Callable
 
 browser_t = Literal["chrome", "safari", "chromium", "edge", "firefox"]
 

--- a/src/tiktok_uploader/cli.py
+++ b/src/tiktok_uploader/cli.py
@@ -2,13 +2,13 @@
 CLI is a controller for the command line use of this library
 """
 
+import datetime
 from argparse import ArgumentParser, Namespace
 from os.path import exists, join
-import datetime
 
-from tiktok_uploader.upload import upload_video
 from tiktok_uploader.auth import login_accounts, save_cookies
 from tiktok_uploader.types import ProxyDict
+from tiktok_uploader.upload import upload_video
 
 
 def main() -> None:

--- a/src/tiktok_uploader/config.py
+++ b/src/tiktok_uploader/config.py
@@ -1,9 +1,9 @@
 from enum import Enum
 from pathlib import Path
 from typing import Annotated
-import toml
 
-from pydantic import BaseModel, Field, HttpUrl, ConfigDict, field_validator
+import toml
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 
 class StrictModel(BaseModel):

--- a/src/tiktok_uploader/proxy_auth_extension/proxy_auth_extension.py
+++ b/src/tiktok_uploader/proxy_auth_extension/proxy_auth_extension.py
@@ -1,6 +1,7 @@
-import zipfile
-import os
 import json
+import os
+import zipfile
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 

--- a/src/tiktok_uploader/types.py
+++ b/src/tiktok_uploader/types.py
@@ -1,7 +1,6 @@
-from typing import TypedDict, Literal
-
 from datetime import datetime
 from http.cookiejar import Cookie as HttpCookie
+from typing import Literal, TypedDict
 
 
 class ProxyDict(TypedDict, total=False):

--- a/src/tiktok_uploader/upload.py
+++ b/src/tiktok_uploader/upload.py
@@ -7,33 +7,31 @@ upload_video : Uploads a single TikTok video
 upload_videos : Uploads multiple TikTok videos
 """
 
-from os.path import abspath, exists
-import time
-import pytz
 import datetime
 import threading
+import time
+from collections.abc import Callable
+from os.path import abspath, exists
+from typing import Any, Literal
 
-from selenium.webdriver.common.by import By
-
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.keys import Keys
+import pytz
 from selenium.common.exceptions import (
     ElementClickInterceptedException,
-    TimeoutException,
     NoSuchElementException,
+    TimeoutException,
 )
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
-from tiktok_uploader.browsers import get_browser
-from tiktok_uploader.auth import AuthBackend
 from tiktok_uploader import config, logger
-from tiktok_uploader.utils import bold, green, red
+from tiktok_uploader.auth import AuthBackend
+from tiktok_uploader.browsers import get_browser
 from tiktok_uploader.proxy_auth_extension.proxy_auth_extension import proxy_is_working
-
-from tiktok_uploader.types import VideoDict, ProxyDict, Cookie
-from typing import Any, Literal
-from collections.abc import Callable
+from tiktok_uploader.types import Cookie, ProxyDict, VideoDict
+from tiktok_uploader.utils import bold, green, red
 
 
 def upload_video(

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -2,8 +2,9 @@
 Test the browsers module.
 """
 
-import tiktok_uploader.browsers as browsers
 import pytest
+
+import tiktok_uploader.browsers as browsers
 
 SUPPORTED_BROWSERS = ["chrome", "firefox", "safari", "edge"]
 SERVICES = ["chrome", "firefox", "edge"]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -2,20 +2,22 @@
 Tests uploader
 """
 
-from tiktok_uploader.upload import (
-    _convert_videos_dict,
-    _get_valid_schedule_minute,
-    _check_valid_schedule,
-    upload_video,
-)
-from tiktok_uploader.types import VideoDict
-import os
 import datetime
+import os
+from typing import Literal
+from unittest.mock import MagicMock, patch
+
+import pytz
 from freezegun import freeze_time
 from pytest import raises
-import pytz
-from unittest.mock import patch, MagicMock
-from typing import Literal
+
+from tiktok_uploader.types import VideoDict
+from tiktok_uploader.upload import (
+    _check_valid_schedule,
+    _convert_videos_dict,
+    _get_valid_schedule_minute,
+    upload_video,
+)
 
 # before each create a file called test.mp4 and test.jpg
 FILENAME = "test.mp4"


### PR DESCRIPTION
I was unaware the default ruff configuration did **not** sort imports.

This change:
- migrates from `.ruff-toml` to `ruff.toml`
- applies sorted imports